### PR TITLE
Update version to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-lancedb" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,34 +7,41 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 1fe7df4e5961e088d73ea721d027d698f97c0ed95e573fb380c98d0839ce6279
+  sha256: c7ca50aca8133caa250107e4c4115f119d7a6f6da36b83b5ac8b4d21cbabbfed
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core
-    
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
-    - lancedb >=0.9.0,<0.10.0
+    - lancedb
 
-# Unable to run tests and check imports, lancedb is not in the main channel.
 test:
+  source_files:
+    - tests
+    - pyproject.toml
+  imports:
+    - opentelemetry.instrumentation.lancedb
   commands:
     - pip check
+    - pytest -vvv
   requires:
     - pip
+    - pytest
+    - pandas
+    - lancedb
 
 about:
   home: https://www.traceloop.com/openllmetry
@@ -51,4 +58,3 @@ extra:
     - timkpaine
   skip-lints:
     - invalid_url
-    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
-  run_constrained:
-    - lancedb
 
 test:
   source_files:


### PR DESCRIPTION
opentelemetry-instrumentation-lancedb 0.57.0

**Destination channel:** defaults

### Links

- [PKG-13420](https://anaconda.atlassian.net/browse/PKG-13420) 
- [Upstream repository](https://github.com/traceloop/openllmetry/blob/v0.57.0/packages/opentelemetry-instrumentation-lancedb/pyproject.toml)

### Explanation of changes:
- New version number
- Running tests


[PKG-13420]: https://anaconda.atlassian.net/browse/PKG-13420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ